### PR TITLE
Issue loading player on iPads that have iOS 13+ 

### DIFF
--- a/dist/js/green-audio-player.js
+++ b/dist/js/green-audio-player.js
@@ -229,10 +229,10 @@ var GreenAudioPlayer = /*#__PURE__*/function () {
       if (isiOS()) {
         // iOS does not support "canplay" event
         this.player.addEventListener('loadedmetadata', this.hideLoadingIndicator.bind(self)); // iOS does not let "volume" property to be set programmatically
-
         this.audioPlayer.querySelector('.volume').style.display = 'none';
         this.audioPlayer.querySelector('.controls').style.marginRight = '0';
       }
+      
     }
   }, {
     key: "isDraggable",

--- a/dist/js/green-audio-player.js
+++ b/dist/js/green-audio-player.js
@@ -212,8 +212,21 @@ var GreenAudioPlayer = /*#__PURE__*/function () {
     key: "overcomeIosLimitations",
     value: function overcomeIosLimitations() {
       var self = this;
+      
+      function isiOS() {
+        return [
+              'iPad Simulator',
+              'iPhone Simulator',
+              'iPod Simulator',
+              'iPad',
+              'iPhone',
+              'iPod'
+            ].includes(navigator.platform)
+            // iPad on iOS 13 detection
+            || (navigator.userAgent.includes("Mac") && "ontouchend" in document)
+      }
 
-      if (this.isDevice) {
+      if (isiOS()) {
         // iOS does not support "canplay" event
         this.player.addEventListener('loadedmetadata', this.hideLoadingIndicator.bind(self)); // iOS does not let "volume" property to be set programmatically
 


### PR DESCRIPTION
There is an issue with the overcomeIosLimitations() function not correctly working on iPads running iOS 13+. This causes the player to not load anything on these iPads. Updating the overcomeIosLimitations()  function using the code suggested by "Lastone17" at: #32 has fixed the issue for me and I wanted to suggest adding it.