### PR TITLE
added data-duration attribute option

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -80,6 +80,11 @@ class GreenAudioPlayer {
         this.directionAware();
         this.overcomeIosLimitations();
 
+        if('data-duration' in this.player.attributes)
+        {
+          self.totalTime.textContent = GreenAudioPlayer.formatTime(this.player.getAttribute("data-duration"));
+        }
+
         if ('autoplay' in this.player.attributes) {
             const promise = this.player.play();
             if (promise !== undefined) {


### PR DESCRIPTION
Hello

Safari does not support the preload=metadata option.  It loads the whole audio file. 
Which is complicated if it's a big file. 

I've added support for a data-duration attribute on the <audio> tag . That way you can specify manually the sound file duration before metadata gets loaded. 

Take care :)